### PR TITLE
Add a defaultClass argument that provides a fallback class for smaller devices when no value is specified In the getResponsiveClasses function.

### DIFF
--- a/craft.tsx
+++ b/craft.tsx
@@ -251,7 +251,7 @@ const Box = ({
   };
 
   const getResponsiveClasses = (
-    prop: ResponsiveValue<any>,
+    prop: any,
     classMap: Record<string | number, string>
   ) => {
     if (!prop) return "";

--- a/craft.tsx
+++ b/craft.tsx
@@ -50,6 +50,7 @@ type BoxProps = {
     | "row"
     | "col"
     | {
+        base?: "row" | "col";
         sm?: "row" | "col";
         md?: "row" | "col";
         lg?: "row" | "col";
@@ -59,6 +60,7 @@ type BoxProps = {
   wrap?:
     | boolean
     | {
+        base?: boolean;
         sm?: boolean;
         md?: boolean;
         lg?: boolean;
@@ -67,13 +69,34 @@ type BoxProps = {
       };
   gap?:
     | number
-    | { sm?: number; md?: number; lg?: number; xl?: number; "2xl"?: number };
+    | {
+        base?: number;
+        sm?: number;
+        md?: number;
+        lg?: number;
+        xl?: number;
+        "2xl"?: number;
+      };
   cols?:
     | number
-    | { sm?: number; md?: number; lg?: number; xl?: number; "2xl"?: number };
+    | {
+        base?: number;
+        sm?: number;
+        md?: number;
+        lg?: number;
+        xl?: number;
+        "2xl"?: number;
+      };
   rows?:
     | number
-    | { sm?: number; md?: number; lg?: number; xl?: number; "2xl"?: number };
+    | {
+        base?: number;
+        sm?: number;
+        md?: number;
+        lg?: number;
+        xl?: number;
+        "2xl"?: number;
+      };
 };
 
 // Layout Component
@@ -231,10 +254,12 @@ const Box = ({
     prop: any,
     classMap: Record<string | number, string>
   ) => {
+    if (!prop) return "";
+
     if (typeof prop === "object") {
       return Object.entries(prop)
         .map(([breakpoint, value]) => {
-          const prefix = breakpoint === "sm" ? "" : `${breakpoint}:`;
+          const prefix = breakpoint === "base" ? "" : `${breakpoint}:`;
           return `${prefix}${classMap[value as keyof typeof classMap] || ""}`;
         })
         .join(" ");

--- a/craft.tsx
+++ b/craft.tsx
@@ -50,6 +50,7 @@ type BoxProps = {
     | "row"
     | "col"
     | {
+        base?: "row" | "col";
         sm?: "row" | "col";
         md?: "row" | "col";
         lg?: "row" | "col";
@@ -59,6 +60,7 @@ type BoxProps = {
   wrap?:
     | boolean
     | {
+        base?: boolean;
         sm?: boolean;
         md?: boolean;
         lg?: boolean;
@@ -67,13 +69,34 @@ type BoxProps = {
       };
   gap?:
     | number
-    | { sm?: number; md?: number; lg?: number; xl?: number; "2xl"?: number };
+    | {
+        base?: number;
+        sm?: number;
+        md?: number;
+        lg?: number;
+        xl?: number;
+        "2xl"?: number;
+      };
   cols?:
     | number
-    | { sm?: number; md?: number; lg?: number; xl?: number; "2xl"?: number };
+    | {
+        base?: number;
+        sm?: number;
+        md?: number;
+        lg?: number;
+        xl?: number;
+        "2xl"?: number;
+      };
   rows?:
     | number
-    | { sm?: number; md?: number; lg?: number; xl?: number; "2xl"?: number };
+    | {
+        base?: number;
+        sm?: number;
+        md?: number;
+        lg?: number;
+        xl?: number;
+        "2xl"?: number;
+      };
 };
 
 // Layout Component
@@ -228,13 +251,15 @@ const Box = ({
   };
 
   const getResponsiveClasses = (
-    prop: any,
+    prop: ResponsiveValue<any>,
     classMap: Record<string | number, string>
   ) => {
+    if (!prop) return "";
+
     if (typeof prop === "object") {
       return Object.entries(prop)
         .map(([breakpoint, value]) => {
-          const prefix = breakpoint === "sm" ? "" : `${breakpoint}:`;
+          const prefix = breakpoint === "base" ? "" : `${breakpoint}:`;
           return `${prefix}${classMap[value as keyof typeof classMap] || ""}`;
         })
         .join(" ");


### PR DESCRIPTION
Set Default Values: For each responsive prop (direction, wrap, gap, cols, rows), provide default values for smaller devices, i.e., devices smaller than sm.
Update the getResponsiveClasses function to use the base breakpoint